### PR TITLE
Update pal-platform / curl to 7.76

### DIFF
--- a/lib/pal-platform/pal-platform.json
+++ b/lib/pal-platform/pal-platform.json
@@ -61,11 +61,11 @@
         "to": "Middleware/parsec_se_driver/parsec_se_driver"
       },
       "curl": {
-        "version": "7.75.0",
+        "version": "7.76.0",
         "from": {
           "protocol": "git",
           "location": "https://github.com/curl/curl.git",
-          "tag": "curl-7_75_0"
+          "tag": "curl-7_76_0"
         },
         "to": "Middleware/curl/curl"
       }
@@ -127,11 +127,11 @@
         "to": "Middleware/mbedtls/mbedtls"
       },
       "curl": {
-        "version": "7.75.0",
+        "version": "7.76.0",
         "from": {
           "protocol": "git",
           "location": "https://github.com/curl/curl.git",
-          "tag": "curl-7_75_0"
+          "tag": "curl-7_76_0"
         },
         "to": "Middleware/curl/curl"
       }


### PR DESCRIPTION
## Description

Update curl to 7.76. 
Good practice to stay up-to-date and this also fixes one known [CVE](https://curl.se/docs/CVE-2021-22890.html).

## Test instructions

Doing firmware update tests is enough.

## Check list

### API change(s)

 - [x] Not applicable.
 - [ ] API is backwards compatible.
 - [ ] API documentation is updated.

### Example applications updated

 - [x] Not applicable.
 
