### PR TITLE
Remove MBED_CLIENT macro deprecated in 4.8.0

### DIFF
--- a/cmake/edge_configure.cmake
+++ b/cmake/edge_configure.cmake
@@ -163,7 +163,6 @@ if (NOT DEFINED CLOUD_CLIENT_CONFIG)
   MESSAGE ("Using default Device Management Client config: ${CLOUD_CLIENT_CONFIG}")
 endif()
 add_definitions ("-DMBED_CLOUD_CLIENT_USER_CONFIG_FILE=\"${CLOUD_CLIENT_CONFIG}\"")
-add_definitions ("-DMBED_CLIENT_USER_CONFIG_FILE=\"${CLOUD_CLIENT_CONFIG}\"")
 
 # Internal eventloop thread stack size
 if (NOT DEFINED NS_HAL_PAL_EVENLOOP_STACK_SIZE)


### PR DESCRIPTION
MBED_CLIENT_USER_CONFIG_FILE was deprecated in PDMC 4.8.0.
Its enough to define MBED_CLOUD_CLIENT_USER_CONFIG_FILE.

# Mbed Edge pull request

`
Please fill this pull request template to describe your pull request.
If it introduces API breaks please describe it in detail.
`

## Description

`submitter: Please add a description of your PR here.`

## Test instructions

`Submitter: Please add instructions to test your PR here.`

`If your pull request is a fix for a defect please write instructions
to reproduce the defect.`

## Check list

### API change(s)

 - [ ] Not applicable.
 - [ ] API is backwards compatible.
 - [ ] API documentation is updated.

### Example applications updated

 - [ ] Not applicable.
 

