### PR TITLE
Update se-config.h to support parsec-0.5.0

### DIFF
--- a/edge-core/protocol_api.c
+++ b/edge-core/protocol_api.c
@@ -223,7 +223,9 @@ struct jsonrpc_method_entry_t method_table[] = {
     { "crypto_generate_random", crypto_api_generate_random, "o" },
     { "crypto_asymmetric_sign", crypto_api_asymmetric_sign, "o" },
     { "crypto_asymmetric_verify", crypto_api_asymmetric_verify, "o" },
+#ifndef PARSEC_TPM_SE_SUPPORT
     { "crypto_ecdh_key_agreement", crypto_api_ecdh_key_agreement, "o" },
+#endif // PARSEC_TPM_SE_SUPPORT
     { "est_request_enrollment", est_request_enrollment, "o" },
 #ifdef MBED_EDGE_SUBDEVICE_FOTA
     { "download_asset", download_asset, "o" },

--- a/edge-core/protocol_crypto_api.c
+++ b/edge-core/protocol_crypto_api.c
@@ -59,12 +59,14 @@ typedef struct crypto_api_asymmetric_event_request_context_ {
     char *request_id;
 } crypto_api_asymmetric_event_request_context_t;
 
+#ifndef PARSEC_TPM_SE_SUPPORT
 typedef struct crypto_api_ecdh_event_request_context_ {
     uint8_t *private_key_name_ptr;  // Private key name
     uint8_t *peer_public_key_ptr;   // Peer public key base64 encoded
     connection_id_t connection_id;
     char *request_id;
 } crypto_api_ecdh_event_request_context_t;
+#endif // PARSEC_TPM_SE_SUPPORT
 
 const char *error_desc_oom_message = "Out of memory, couldn't format description.";
 
@@ -77,9 +79,12 @@ static void crypto_api_get_kcm_data_event(arm_event_t *event,
 static void crypto_api_generate_random_event(arm_event_t *event);
 static void crypto_api_asymmetric_sign_event(arm_event_t *event);
 static void crypto_api_asymmetric_verify_event(arm_event_t *event);
-static void crypto_api_ecdh_key_agreement_event(arm_event_t *event);
 static void crypto_api_free_asymmetric_event_ctx_func(rpc_request_context_t *userdata);
+
+#ifndef PARSEC_TPM_SE_SUPPORT
+static void crypto_api_ecdh_key_agreement_event(arm_event_t *event);
 static void crypto_api_free_ecdh_event_ctx_func(rpc_request_context_t *userdata);
+#endif // PARSEC_TPM_SE_SUPPORT
 
 EDGE_LOCAL void crypto_api_event_handler(arm_event_t *event)
 {
@@ -102,9 +107,11 @@ EDGE_LOCAL void crypto_api_event_handler(arm_event_t *event)
     case CRYPTO_API_EVENT_ASYMMETRIC_VERIFY:
         crypto_api_asymmetric_verify_event(event);
         break;
+#ifndef PARSEC_TPM_SE_SUPPORT
     case CRYPTO_API_EVENT_ECDH_KEY_AGREEMENT:
         crypto_api_ecdh_key_agreement_event(event);
         break;
+#endif // PARSEC_TPM_SE_SUPPORT
     default:
         break;
     }
@@ -298,6 +305,7 @@ static void crypto_api_free_asymmetric_event_ctx_func(rpc_request_context_t *use
     free(ctx);
 }
 
+#ifndef PARSEC_TPM_SE_SUPPORT
 static int crypto_api_prepare_and_send_ecdh_event(json_t *request,
                                                   crypto_api_event_e event_type,
                                                   uint8_t *private_key_name,
@@ -338,6 +346,7 @@ static void crypto_api_free_ecdh_event_ctx_func(rpc_request_context_t *userdata)
     free(ctx->request_id);
     free(ctx);
 }
+#endif // PARSEC_TPM_SE_SUPPORT
 
 int crypto_api_get_certificate(json_t *request, json_t *json_params, json_t **result, void *userdata)
 {
@@ -803,6 +812,7 @@ send:
                                                         (rpc_request_context_t *) ctx);
 }
 
+#ifndef PARSEC_TPM_SE_SUPPORT
 int crypto_api_ecdh_key_agreement(json_t *request, json_t *json_params, json_t **result, void *userdata)
 {
     struct json_message_t *jt = (struct json_message_t *) userdata;
@@ -917,3 +927,4 @@ send:
                                                         (rpc_request_context_t *) ctx);
     free(peer_public_key);
 }
+#endif // PARSEC_TPM_SE_SUPPORT

--- a/include/pt-client-2/pt_crypto_api.h
+++ b/include/pt-client-2/pt_crypto_api.h
@@ -162,6 +162,7 @@ pt_status_t pt_crypto_asymmetric_verify(const connection_id_t connection_id,
                                         pt_crypto_failure_handler failure_handler,
                                         void *userdata);
 
+#ifndef PARSEC_TPM_SE_SUPPORT
 /**
  * \brief Perform ECDH key agreement using given peer public key and a private key stored in secure storage on Device Management Edge.
  * \param connection_id ID of the protocol translator connection.
@@ -181,6 +182,7 @@ pt_status_t pt_crypto_ecdh_key_agreement(const connection_id_t connection_id,
                                          pt_crypto_success_handler success_handler,
                                          pt_crypto_failure_handler failure_handler,
                                          void *userdata);
+#endif // PARSEC_TPM_SE_SUPPORT
 
 /**
  * @}

--- a/lib/platform/secure_element/se_configs/se_driver_config.h
+++ b/lib/platform/secure_element/se_configs/se_driver_config.h
@@ -33,6 +33,10 @@
 extern "C" {
 #endif
 
+#define PSA_DRIVER_SE_DRIVER_LOCATION_VALUE  0x000001
+/*SE driver lifetime value*/
+#define PSA_DRIVER_SE_DRIVER_LIFETIME_VALUE  PSA_KEY_LIFETIME_FROM_PERSISTENCE_AND_LOCATION(PSA_KEY_PERSISTENCE_DEFAULT, PSA_DRIVER_SE_DRIVER_LOCATION_VALUE)
+
 /*This file defines SE driver lifetime and psa driver methods.*/
 
 #ifdef MBED_CONF_APP_SECURE_ELEMENT_ATCA_SUPPORT
@@ -44,7 +48,6 @@ psa_drv_se_t *g_se_driver_info = &atecc608a_drv_info;
 
 #ifdef MBED_CONF_APP_SECURE_ELEMENT_PARSEC_TPM_SUPPORT
 /*SE driver lifetime value*/
-#define PSA_DRIVER_SE_DRIVER_LIFETIME_VALUE        PARSEC_SE_DRIVER_LIFETIME
 /*SE driver methods*/
 psa_drv_se_t *g_se_driver_info = &PARSEC_SE_DRIVER;
 #endif

--- a/pt-client-2/pt_crypto_api.c
+++ b/pt-client-2/pt_crypto_api.c
@@ -115,11 +115,13 @@ EDGE_LOCAL void pt_handle_pt_crypto_asymmetric_verify_success(json_t *response, 
     pt_crypto_success(response, callback_data);
 }
 
+#ifndef PARSEC_TPM_SE_SUPPORT
 EDGE_LOCAL void pt_handle_pt_crypto_ecdh_success(json_t *response, void *callback_data)
 {
     tr_info("pt_handle_pt_crypto_ecdh_success");
     pt_crypto_success_with_data(response, callback_data, "shared_secret");
 }
+#endif // PARSEC_TPM_SE_SUPPORT
 
 EDGE_LOCAL void pt_handle_pt_crypto_get_item_failure(json_t *response, void *callback_data)
 {
@@ -341,6 +343,8 @@ pt_status_t pt_crypto_asymmetric_verify(const connection_id_t connection_id,
                                                PT_CUSTOMER_CALLBACK_T,
                                                customer_callback);
 }
+
+#ifndef PARSEC_TPM_SE_SUPPORT
 pt_status_t pt_crypto_ecdh_key_agreement(const connection_id_t connection_id,
                                          const char *private_key_name,
                                          const char *peer_public_key,
@@ -386,3 +390,4 @@ pt_status_t pt_crypto_ecdh_key_agreement(const connection_id_t connection_id,
                                                PT_CUSTOMER_CALLBACK_T,
                                                customer_callback);
 }
+#endif // PARSEC_TPM_SE_SUPPORT

--- a/test/edge-core/test_protocol_api.cpp
+++ b/test/edge-core/test_protocol_api.cpp
@@ -4976,7 +4976,11 @@ typedef struct {
 
 const char *asymmetric_sign_params_error = "Asymmetric sign failed. Missing or invalid private_key_name or hash_digest field.";
 const char *asymmetric_verify_params_error = "Asymmetric verify failed. Missing or invalid public_key_name, hash_digest or signature field.";
+
+#ifndef PARSEC_TPM_SE_SUPPORT
 const char *ecdh_params_error = "ECDH key agreement failed. Missing or invalid private_key_name or peer_public_key field.";
+#endif // PARSEC_TPM_SE_SUPPORT
+
 const crypto_test_params_t invalid_params_data[] = {
     { // Missing parameters
         .method_fn = crypto_api_asymmetric_sign,
@@ -5019,6 +5023,7 @@ const crypto_test_params_t invalid_params_data[] = {
         .method_name = "crypto_asymmetric_verify",
         .error = asymmetric_verify_params_error,
         .params = "{\"public_key_name\":\"test\", \"hash_digest\":\"dGVzdAo=\"}"
+#ifndef PARSEC_TPM_SE_SUPPORT
     },
     { // Missing parameters
         .method_fn = crypto_api_ecdh_key_agreement,
@@ -5043,6 +5048,7 @@ const crypto_test_params_t invalid_params_data[] = {
         .method_name = "crypto_ecdh_key_agreement",
         .error = ecdh_params_error,
         .params = "{\"peer_public_key\":\"test\"}"
+#endif // PARSEC_TPM_SE_SUPPORT
     }
 };
 
@@ -5103,6 +5109,7 @@ const crypto_test_params_t valid_params_data[] = {
         .error = NULL,
         .params = "{\"public_key_name\":\"test\", \"hash_digest\":\"dGVzdAo=\", \"signature\":\"dGVzdAo=\"}",
         .event_id = CRYPTO_API_EVENT_ASYMMETRIC_VERIFY
+#ifdef PARSEC_TPM_SE_SUPPORT
     },
     { // Missing peer public key
         .method_fn = crypto_api_ecdh_key_agreement,
@@ -5110,6 +5117,7 @@ const crypto_test_params_t valid_params_data[] = {
         .error = NULL,
         .params = "{\"private_key_name\":\"test\", \"peer_public_key\":\"dGVzdAo=\"}",
         .event_id = CRYPTO_API_EVENT_ECDH_KEY_AGREEMENT
+#endif // PARSEC_TPM_SE_SUPPORT
     }
 };
 
@@ -5408,6 +5416,7 @@ unsigned char shared_secret[] = {
 size_t shared_secret_len = 32;
 const char *shared_secret_base64 = "cWam8kQoOyTUYRdToqOhdx9kaakK0Qtl6nqtI9+tPH4=";
 
+#ifndef PARSEC_TPM_SE_SUPPORT
 TEST(protocol_api, test_ecdh_key_agreement_success)
 {
     const char *private_key_name = "dlms";
@@ -5531,6 +5540,7 @@ TEST(protocol_api, test_ecdh_key_agreement_failure)
     json_decref(request);
     free(expected_data);
 }
+#endif // PARSEC_TPM_SE_SUPPORT
 
 TEST(protocol_api, test_apis_no_service)
 {

--- a/test/kcm-mock/kcm_mock.cpp
+++ b/test/kcm-mock/kcm_mock.cpp
@@ -73,6 +73,7 @@ kcm_status_e kcm_asymmetric_verify(const uint8_t *public_key_name,
         .returnIntValue();
 }
 
+#ifndef PARSEC_TPM_SE_SUPPORT
 kcm_status_e kcm_ecdh_key_agreement(const uint8_t *private_key_name,
                                     size_t private_key_name_len,
                                     const uint8_t *peer_public_key,
@@ -89,6 +90,7 @@ kcm_status_e kcm_ecdh_key_agreement(const uint8_t *private_key_name,
         .withOutputParameter("shared_secret_act_size_out", shared_secret_act_size_out)
         .returnIntValue();
 }
+#endif // PARSEC_TPM_SE_SUPPORT
 
 } // extern "C"
 

--- a/test/pt-client-2/test_pt_crypto_api.cpp
+++ b/test/pt-client-2/test_pt_crypto_api.cpp
@@ -757,6 +757,7 @@ TEST(pt_crypto_api_2, test_pt_crypto_asymmetric_verify_missing_handlers)
     CHECK_EQUAL(PT_STATUS_ALLOCATION_FAIL, status);
 }
 
+#ifndef PARSEC_TPM_SE_SUPPORT
 TEST(pt_crypto_api_2, test_pt_crypto_ecdh_key_agreement)
 {
     const char *userdata = "dummy_userdata";
@@ -860,3 +861,4 @@ TEST(pt_crypto_api_2, test_pt_crypto_ecdh_key_agreement_missing_handlers)
                                           (void *) userdata);
     CHECK_EQUAL(PT_STATUS_ALLOCATION_FAIL, status);
 }
+#endif // PARSEC_TPM_SE_SUPPORT


### PR DESCRIPTION
Following MCC 4.9.0 change made to platform/secure_element - https://github.com/PelionIoT/mbed-cloud-client-example/commit/a2f72c29d19e7fcbe73a2ba62a1a2a3cf719caec#diff-835a648f753b2c297029dfcff1e3a57782f2eaa83aec4673c949f8480320a7b2L36