### PR TITLE
edge-tool: setup.py should install edge_tool.py

### DIFF
--- a/edge-tool/setup.py
+++ b/edge-tool/setup.py
@@ -35,4 +35,5 @@ setup(
      install_requires=requirements,
      license='Apache 2.0',
      description='Tool to convert the development certificate to CBOR formatted object',
+     scripts=['edge_tool.py', 'cbor_converter.py'],
 )


### PR DESCRIPTION
The edge_tool.py and cbor_converter.py scripts are missing when
using a distribution created from setup.py.

See here for more info:
https://docs.python.org/3/distutils/setupscript.html#distutils-installing-scripts
 

