### PR TITLE
Update pal-platform.json

### DIFF
--- a/lib/pal-platform/pal-platform.json
+++ b/lib/pal-platform/pal-platform.json
@@ -34,11 +34,11 @@
     },
     "middleware": {
       "mbedtls": {
-        "version": "2.25.0",
+        "version": "2.27.0",
         "from": {
           "protocol": "git",
           "location": "https://github.com/ARMmbed/mbedtls.git",
-          "tag": "mbedtls-2.25.0"
+          "tag": "mbedtls-2.27.0"
         },
         "to": "Middleware/mbedtls/mbedtls"
       },
@@ -81,11 +81,11 @@
     },
     "middleware": {
       "mbedtls": {
-        "version": "2.25.0",
+        "version": "2.27.0",
         "from": {
           "protocol": "git",
           "location": "https://github.com/ARMmbed/mbedtls.git",
-          "tag": "mbedtls-2.25.0"
+          "tag": "mbedtls-2.27.0"
         },
         "to": "Middleware/mbedtls/mbedtls"
       },
@@ -118,11 +118,11 @@
     },
     "middleware": {
       "mbedtls": {
-        "version": "2.25.0",
+        "version": "2.27.0",
         "from": {
           "protocol": "git",
           "location": "https://github.com/ARMmbed/mbedtls.git",
-          "tag": "mbedtls-2.25.0"
+          "tag": "mbedtls-2.27.0"
         },
         "to": "Middleware/mbedtls/mbedtls"
       },
@@ -210,11 +210,11 @@
     },
     "middleware": {
       "mbedtls": {
-        "version": "2.25.0",
+        "version": "2.27.0",
         "from": {
           "protocol": "git",
           "location": "https://github.com/ARMmbed/mbedtls.git",
-          "tag": "mbedtls-2.25.0"
+          "tag": "mbedtls-2.27.0"
         },
         "to": "Middleware/mbedtls/mbedtls"
       },


### PR DESCRIPTION
Update from 2.25.0 to 2.27.0.

## Test instructions

Smoke tests would be enough.

## Check list

### API change(s)

 - [x] Not applicable.
 - [ ] API is backwards compatible.
 - [ ] API documentation is updated.

### Example applications updated

 - [x] Not applicable.
 

