### PR TITLE
Added a patch which links `libm` with fccstorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ The contents of the repository.
     git submodule update --init --recursive
     ```
 
+1. If there are any patches, then apply them now -
+
+    ```
+    [ -d "patches" ] && git apply patches/*
+    ```
+
 1. Install Rust
 
     Note: This is required only when building with Parsec.
@@ -92,6 +98,11 @@ The contents of the repository.
 First, fetch the dependencies
 ```
 git submodule update --init --recursive
+```
+
+If there are any patches, then apply them now -
+```
+[ -d "patches" ] && git apply patches/*
 ```
 
 The edge-core docker image is a developer build with firmware update enabled. Thus, place the `mbed_cloud_dev_credentials.c` and `update_default_resources.c` in `config` folder before starting the build -

--- a/patches/0001-Link-libm-when-compiling-parsec_se_driver-with-cargo.patch
+++ b/patches/0001-Link-libm-when-compiling-parsec_se_driver-with-cargo.patch
@@ -1,0 +1,26 @@
+From 83e1175e29976f667755f9d8104680999dd439ec Mon Sep 17 00:00:00 2001
+From: Yash Goyal <yash.goyal@pelion.com>
+Date: Sun, 26 Sep 2021 18:45:30 -0700
+Subject: [PATCH] Link libm when compiling parsec_se_driver with cargo and
+ rustc v1.55.0
+
+---
+ factory-configurator-client/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/mbed-cloud-client/factory-configurator-client/CMakeLists.txt b/lib/mbed-cloud-client/factory-configurator-client/CMakeLists.txt
+index 74647511f..1272dd74f 100644
+--- a/lib/mbed-cloud-client/factory-configurator-client/CMakeLists.txt
++++ b/lib/mbed-cloud-client/factory-configurator-client/CMakeLists.txt
+@@ -126,7 +126,7 @@ if(PARSEC_TPM_SE_SUPPORT)
+     set_property(TARGET parsec_driver PROPERTY IMPORTED_LOCATION_RELEASE
+         "${CMAKE_CURRENT_SOURCE_DIR}/../../pal-platform/Middleware/parsec_se_driver/parsec_se_driver/target/release/libparsec_se_driver.a")
+ 
+-    target_link_libraries(fccstorage parsec_driver -ldl)
++    target_link_libraries(fccstorage parsec_driver -ldl -lm)
+ endif()
+ 
+ # key-config-manager library
+-- 
+2.17.1
+


### PR DESCRIPTION
This is required when compiling the parsec_se_driver library with cargo and
rustc version 1.55.0. Adding this temporary fix for the release. Need to upstream this
patch and remove it in later releases.

Fixes -
```
/usr/bin/ld: ../../lib/mbed-cloud-client/factory-configurator-client/../../pal-platform/Middleware/parsec_se_driver/parsec_se_driver/target/release/libparsec_se_driver.a(std-008055cc7d873802.std.cf1c8f7e-cgu.0.rcgu.o): undefined reference to symbol 'fma@@GLIBC_2.2.5'
/lib/x86_64-linux-gnu/libm.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```