### PR TITLE
TLS, curl update, make tests run again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog for Edge
 
+## Release 0.20.0
+
+* Update Mbed TLS to version 2.28.0 from version 2.27.0. This closes [security vulnerability CVE-2021-44732](https://github.com/advisories/GHSA-7g56-f7p4-fmcq).
+* Update curl to version 7.83.0 from version 7.76.0. This closes multiple security vulnerabilities, see [curl releases](https://curl.se/docs/releases.html).
+
 ## Release 0.19.1
 
 * Implemented combined update callbacks for bootloader. This assumes that boot capsule update is implemented on the device.

--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ At the repository root a Makefile is present with shortcuts to have specific
 build templates.
 
 At first it is recommended to run the tests to see that the build environment is
-in correct shape: `make run-tests`. When environment is good to go the next
+in correct shape: `make -f Makefile.test run-tests`. When environment is good to go the next
 step is to create a developer certificate build: `make build-developer`.
 
 Default Makefile:

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -60,9 +60,7 @@ if (PARSEC_TPM_SE_SUPPORT OR (FOTA_ENABLE AND NOT MBED_CLOUD_CLIENT_CURL_DYNAMIC
 
     add_subdirectory("pal-platform/Middleware/parsec_se_driver")
     add_subdirectory("pal-platform/Middleware/trusted_storage")
-
-  else ()
-    add_subdirectory("pal-platform/Middleware/curl/curl")
   endif ()
-
-endif ()
+  # This cannot be included until after pal-platform.py is run, as curl does not exist before that
+  add_subdirectory("${ROOT_HOME}/lib/pal-platform/Middleware/curl/")
+  endif ()

--- a/lib/pal-platform/Middleware/curl/curl.cmake
+++ b/lib/pal-platform/Middleware/curl/curl.cmake
@@ -15,7 +15,7 @@
 #################################################################################
 
 if (NOT MBED_CLOUD_CLIENT_CURL_DYNAMIC_LINK)
-    set (CMAKE_USE_OPENSSL OFF CACHE BOOL "disable openssl" FORCE)
+    set (CURL_USE_OPENSSL OFF CACHE BOOL "disable openssl" FORCE)
     set (BUILD_TESTING OFF CACHE BOOL "disable testing" FORCE)
     set (BUILD_CURL_EXE OFF CACHE BOOL "don't build exe" FORCE)
     set (BUILD_SHARED_LIBS OFF CACHE BOOL "don't build share libs" FORCE)

--- a/lib/pal-platform/pal-platform.json
+++ b/lib/pal-platform/pal-platform.json
@@ -34,11 +34,11 @@
     },
     "middleware": {
       "mbedtls": {
-        "version": "2.27.0",
+        "version": "2.28.0",
         "from": {
           "protocol": "git",
           "location": "https://github.com/ARMmbed/mbedtls.git",
-          "tag": "mbedtls-2.27.0"
+          "tag": "mbedtls-2.28.0"
         },
         "to": "Middleware/mbedtls/mbedtls"
       },
@@ -61,11 +61,11 @@
         "to": "Middleware/parsec_se_driver/parsec_se_driver"
       },
       "curl": {
-        "version": "7.76.0",
+        "version": "7.83.0",
         "from": {
           "protocol": "git",
           "location": "https://github.com/curl/curl.git",
-          "tag": "curl-7_76_0"
+          "tag": "curl-7_83_0"
         },
         "to": "Middleware/curl/curl"
       }
@@ -81,11 +81,11 @@
     },
     "middleware": {
       "mbedtls": {
-        "version": "2.27.0",
+        "version": "2.28.0",
         "from": {
           "protocol": "git",
           "location": "https://github.com/ARMmbed/mbedtls.git",
-          "tag": "mbedtls-2.27.0"
+          "tag": "mbedtls-2.28.0"
         },
         "to": "Middleware/mbedtls/mbedtls"
       },
@@ -118,20 +118,20 @@
     },
     "middleware": {
       "mbedtls": {
-        "version": "2.27.0",
+        "version": "2.28.0",
         "from": {
           "protocol": "git",
           "location": "https://github.com/ARMmbed/mbedtls.git",
-          "tag": "mbedtls-2.27.0"
+          "tag": "mbedtls-2.28.0"
         },
         "to": "Middleware/mbedtls/mbedtls"
       },
       "curl": {
-        "version": "7.76.0",
+        "version": "7.83.0",
         "from": {
           "protocol": "git",
           "location": "https://github.com/curl/curl.git",
-          "tag": "curl-7_76_0"
+          "tag": "curl-7_83_0"
         },
         "to": "Middleware/curl/curl"
       }
@@ -210,11 +210,11 @@
     },
     "middleware": {
       "mbedtls": {
-        "version": "2.27.0",
+        "version": "2.28.0",
         "from": {
           "protocol": "git",
           "location": "https://github.com/ARMmbed/mbedtls.git",
-          "tag": "mbedtls-2.27.0"
+          "tag": "mbedtls-2.28.0"
         },
         "to": "Middleware/mbedtls/mbedtls"
       },

--- a/test/edge-client-mock/CMakeLists.txt
+++ b/test/edge-client-mock/CMakeLists.txt
@@ -4,6 +4,12 @@ add_definitions(-DMBED_CONF_MBED_TRACE_ENABLE=1)
 if(FOTA_ENABLE)
     add_definitions(-DMBED_EDGE_SUBDEVICE_FOTA)
 endif()
+
+if(NOT EXISTS ${ROOT_HOME}/lib/pal-platform/Middleware/curl/curl/include)
+    message(FATAL_ERROR "curl not found in lib/pal-platform/Middleware/curl/curl/include")
+endif()
+
+include_directories (${ROOT_HOME}/lib/pal-platform/Middleware/curl/curl/include)
 add_library (edge-client-mock-lib ${SOURCES})
 include_directories (../cpputest-custom-types)
 target_include_directories (edge-client-mock-lib PUBLIC ${CPPUTEST_HOME}/include)

--- a/test/edge-server-mock/CMakeLists.txt
+++ b/test/edge-server-mock/CMakeLists.txt
@@ -4,7 +4,12 @@ add_definitions(-DMBED_CONF_MBED_TRACE_ENABLE=1)
 if(FOTA_ENABLE)
     add_definitions(-DMBED_EDGE_SUBDEVICE_FOTA)
 endif()
-add_library (edge-server-mock-lib ${SOURCES})
 
+if(NOT EXISTS ${ROOT_HOME}/lib/pal-platform/Middleware/curl/curl/include)
+    message(FATAL_ERROR "curl not found in lib/pal-platform/Middleware/curl/curl/include")
+endif()
+
+include_directories (${ROOT_HOME}/lib/pal-platform/Middleware/curl/curl/include)
+add_library (edge-server-mock-lib ${SOURCES})
 target_include_directories (edge-server-mock-lib PUBLIC ${CPPUTEST_HOME}/include)
 target_include_directories (edge-server-mock-lib PUBLIC ${ROOT_HOME}/test/test-lib)

--- a/test/generate_coverage.sh
+++ b/test/generate_coverage.sh
@@ -37,6 +37,7 @@ lcov ${SOURCE_PATH_ADJUST:+ --rc geninfo_adjust_src_path="${SOURCE_PATH_ADJUST}"
 lcov ${SOURCE_PATH_ADJUST:+ --rc geninfo_adjust_src_path="${SOURCE_PATH_ADJUST}"} -q -r coverage.info "*/test/*" -o coverage.info
 lcov ${SOURCE_PATH_ADJUST:+ --rc geninfo_adjust_src_path="${SOURCE_PATH_ADJUST}"} -q -r coverage.info "*/lib/cpputest/src/Platforms/Gcc/*" -o coverage.info
 lcov ${SOURCE_PATH_ADJUST:+ --rc geninfo_adjust_src_path="${SOURCE_PATH_ADJUST}"} -q -r coverage.info "*/lib/jansson/*" -o coverage.info
+lcov ${SOURCE_PATH_ADJUST:+ --rc geninfo_adjust_src_path="${SOURCE_PATH_ADJUST}"} -q -r coverage.info "*/lib/jsonrpc/*" -o coverage.info
 lcov ${SOURCE_PATH_ADJUST:+ --rc geninfo_adjust_src_path="${SOURCE_PATH_ADJUST}"} -q -r coverage.info "*/lib/libevent/*" -o coverage.info
 lcov ${SOURCE_PATH_ADJUST:+ --rc geninfo_adjust_src_path="${SOURCE_PATH_ADJUST}"} -q -r coverage.info "*/lib/libwebsockets/*" -o coverage.info
 lcov ${SOURCE_PATH_ADJUST:+ --rc geninfo_adjust_src_path="${SOURCE_PATH_ADJUST}"} -q -r coverage.info "*/lib/mbed-cloud-client/*" -o coverage.info
@@ -52,6 +53,7 @@ gcovr --object-directory . --root "${1}" \
                            -e '.*/test/.*' \
                            -e '.*/lib/cpputest/src/Platforms/Gcc/.*' \
                            -e '.*/lib/jansson/.*' \
+                           -e '.*/lib/jsonrpc/.*' \
                            -e '.*/lib/libevent/.*' \
                            -e '.*/lib/libwebsockets/.*' \
                            -e '.*/lib/mbed-cloud-client/.*' \


### PR DESCRIPTION
# Description

1. Update Mbed TLS version to 2.28.0 to cover for https://github.com/advisories/GHSA-7g56-f7p4-fmcq.
    * Ref: https://tls.mbed.org/tech-updates/security-advisories/mbedtls-security-advisory-2021-12.
1. Also, `curl` has plenty of CVEs, see https://curl.se/docs/vuln-7.82.0.html.
1. The tests didn't run - README.md was not up-to-date and and curl include was not in place.

```
OK (160 tests, 160 ran, 18293 checks, 0 ignored, 0 filtered out, 169 ms)

[ERR ][edge-io]: Cannot remove the socket lock file: /tmp/foo.lock
[ERR ][edge-io]: Cannot unlock the socket lock: /tmp/foo.lock
[ERR ][edge-io]: The socket lock '/tmp/foo.lock' is held by another process. Is there another Edge Core running?
[ERR ][edge-io]: The socket lock file '/tmp/foo.lock' cannot be created. Please check the permissions!
...
OK (8 tests, 8 ran, 31 checks, 0 ignored, 0 filtered out, 1 ms)

```

## Test instructions

`Submitter: Please add instructions to test your PR here.`

## Check list

### API change(s)

 - [x] Not applicable.
 - [ ] API is backwards compatible.
 - [ ] API documentation is updated.

### Example applications updated

 - [x] Not applicable.
 
 ### Changelog
 
 - [x] `CHANGELOG.md` updated.
