### PR TITLE
MbedTLS and cURL update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog for Edge
 
-## Release 0.20.1
+## Release 0.21.0
 
+- Update `Mbed TLS` to version 2.28.2 (from 2.28.1), updated also GitHub domain from ArmMbed to Mbed-TLS.
+- Update `cURL` to version 7.87.0 (from 7.85.0).
 * Add function name to crypto API traces.
 
 ## Release 0.20.0

--- a/lib/pal-platform/pal-platform.json
+++ b/lib/pal-platform/pal-platform.json
@@ -35,11 +35,11 @@
         "to": "Middleware/parsec_se_driver/parsec_se_driver"
       },
       "curl": {
-        "version": "7.85.0",
+        "version": "7.87.0",
         "from": {
           "protocol": "git",
           "location": "https://github.com/curl/curl.git",
-          "tag": "curl-7_85_0"
+          "tag": "curl-7_87_0"
         },
         "to": "Middleware/curl/curl"
       }
@@ -101,11 +101,11 @@
         "to": "Middleware/mbedtls/mbedtls"
       },
       "curl": {
-        "version": "7.85.0",
+        "version": "7.87.0",
         "from": {
           "protocol": "git",
           "location": "https://github.com/curl/curl.git",
-          "tag": "curl-7_85_0"
+          "tag": "curl-7_87_0"
         },
         "to": "Middleware/curl/curl"
       }

--- a/lib/pal-platform/pal-platform.json
+++ b/lib/pal-platform/pal-platform.json
@@ -8,11 +8,11 @@
     },
     "middleware": {
       "mbedtls": {
-        "version": "2.28.1",
+        "version": "2.28.2",
         "from": {
           "protocol": "git",
           "location": "https://github.com/ARMmbed/mbedtls.git",
-          "tag": "mbedtls-2.28.1"
+          "tag": "mbedtls-2.28.2"
         },
         "to": "Middleware/mbedtls/mbedtls"
       },
@@ -55,11 +55,11 @@
     },
     "middleware": {
       "mbedtls": {
-        "version": "2.28.1",
+        "version": "2.28.2",
         "from": {
           "protocol": "git",
           "location": "https://github.com/ARMmbed/mbedtls.git",
-          "tag": "mbedtls-2.28.1"
+          "tag": "mbedtls-2.28.2"
         },
         "to": "Middleware/mbedtls/mbedtls"
       },
@@ -92,11 +92,11 @@
     },
     "middleware": {
       "mbedtls": {
-        "version": "2.28.1",
+        "version": "2.28.2",
         "from": {
           "protocol": "git",
           "location": "https://github.com/ARMmbed/mbedtls.git",
-          "tag": "mbedtls-2.28.1"
+          "tag": "mbedtls-2.28.2"
         },
         "to": "Middleware/mbedtls/mbedtls"
       },
@@ -121,11 +121,11 @@
     },
     "middleware": {
       "mbedtls": {
-        "version": "2.28.1",
+        "version": "2.28.2",
         "from": {
           "protocol": "git",
           "location": "https://github.com/ARMmbed/mbedtls.git",
-          "tag": "mbedtls-2.28.1"
+          "tag": "mbedtls-2.28.2"
         },
         "to": "Middleware/mbedtls/mbedtls"
       },

--- a/lib/pal-platform/pal-platform.json
+++ b/lib/pal-platform/pal-platform.json
@@ -11,7 +11,7 @@
         "version": "2.28.2",
         "from": {
           "protocol": "git",
-          "location": "https://github.com/ARMmbed/mbedtls.git",
+          "location": "https://github.com/Mbed-TLS/mbedtls.git",
           "tag": "mbedtls-2.28.2"
         },
         "to": "Middleware/mbedtls/mbedtls"
@@ -58,7 +58,7 @@
         "version": "2.28.2",
         "from": {
           "protocol": "git",
-          "location": "https://github.com/ARMmbed/mbedtls.git",
+          "location": "https://github.com/Mbed-TLS/mbedtls.git",
           "tag": "mbedtls-2.28.2"
         },
         "to": "Middleware/mbedtls/mbedtls"
@@ -95,7 +95,7 @@
         "version": "2.28.2",
         "from": {
           "protocol": "git",
-          "location": "https://github.com/ARMmbed/mbedtls.git",
+          "location": "https://github.com/Mbed-TLS/mbedtls.git",
           "tag": "mbedtls-2.28.2"
         },
         "to": "Middleware/mbedtls/mbedtls"
@@ -124,7 +124,7 @@
         "version": "2.28.2",
         "from": {
           "protocol": "git",
-          "location": "https://github.com/ARMmbed/mbedtls.git",
+          "location": "https://github.com/Mbed-TLS/mbedtls.git",
           "tag": "mbedtls-2.28.2"
         },
         "to": "Middleware/mbedtls/mbedtls"


### PR DESCRIPTION
# Mbed Edge pull request

## Description

- Update Mbed TLS to version 2.28.2, update repo domain to Mbed-TLS.
- Update cURL to version 7.78.0.

## Test instructions

Build, connect, FOTA.

## Check list

### API change(s)

 - [x] Not applicable.
 - [ ] API is backwards compatible.
 - [ ] API documentation is updated.

### Example applications updated

 - [x] Not applicable.
 
 ### Changelog
 
 - [x] `CHANGELOG.md` updated.

