### PR TITLE
Fix typos (misspell spotted)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -611,9 +611,9 @@ See the release CR-0.4.2 known issue list.
  * Example main thread now handles polling to CPU thermal zone for updating thermal zone thermometer IPSO object.
  * Changed example client to use correct IPSO object id (5432 -> 3303) for the simulated thermometer object.
  * Implemented resettable minimum and maximum resources for CPU thermometer object.
-  `/3303/0/5601` IPSO object path for minumum measured temperature.
+  `/3303/0/5601` IPSO object path for minimum measured temperature.
   `/3303/0/5602` IPSO object path for maximum measured temperature.
-  `/3303/0/5605` IPSO object path for executable resource to reset minumum and maximum measured temperature.
+  `/3303/0/5605` IPSO object path for executable resource to reset minimum and maximum measured temperature.
 
 ### LoRa protocol translator example for WISE-3610
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ cmake -D[MODE] -DFIRMWARE_UPDATE=ON -DFOTA_ENABLE=ON -DMBED_CLOUD_CLIENT_CURL_DY
 make
 ```
 
-Alternativley, in order to use the UC hub library just compile with CMake `-DFIRMWARE_UPDATE=ON` flag.
+Alternatively, in order to use the UC hub library just compile with CMake `-DFIRMWARE_UPDATE=ON` flag.
 
 In addition, you need to set the `#define MBED_CLOUD_CLIENT_UPDATE_STORAGE`.
 The exact value of the define depends on the used Linux distribution and the


### PR DESCRIPTION
Just a a few typos.

## Test instructions

misspell -i "mosquitto" *.md

## Check list

### API change(s)

 - [x] Not applicable.
 - [ ] API is backwards compatible.
 - [ ] API documentation is updated.

### Example applications updated

 - [x] Not applicable.
 
 ### Changelog
 
 - [x] `CHANGELOG.md` updated.

