### PR TITLE
lib/mbed-cloud-client - v 4.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Release 0.21.0
 
+* Update mbed-cloud-client to version 4.13.1.
+    * This disables Asynchronous DNS by default, as device fails to reconnect if some of the pods in the service are restarted.
+    * In such a scenario, the device needs to be restarted (or edge-core process need to be restarted).
+    * We highly recommend updating to this release, if you are using mbed-edge version 0.19.0, 0.19.1 or 0.20.0.
 * Update `Mbed TLS` to version 2.28.2 (from 2.28.1), updated also GitHub domain from ArmMbed to Mbed-TLS.
 * Update `cURL` to version 7.87.0 (from 7.85.0).
 * Add function name to crypto API traces.


### PR DESCRIPTION
## Description

Update from version 4.13.0 to version 4.13.1.

This fixes the PAL DNS v3 related issues with reconnnecting after pod update in service.

## Test instructions

CI covers most.
Pod rolling (done).

## Check list

### API change(s)

 - [x] Not applicable.
 - [ ] API is backwards compatible.
 - [ ] API documentation is updated.

### Example applications updated

 - [x] Not applicable.
 
 ### Changelog
 
 - [x] `CHANGELOG.md` updated.

