### PR TITLE
Use client runners

### DIFF
--- a/.github/workflows/devmode-test-build.yml
+++ b/.github/workflows/devmode-test-build.yml
@@ -15,7 +15,7 @@ jobs:
 
   build:
 
-    runs-on: [ "self-hosted", "edge-builder" ]
+    runs-on: [ "self-hosted", "client" ]
     env:
       SCRIPTS_INTERNAL_DIR: scripts-internal
       EDGE_CONFIGS_DIR: scripts-internal/edge/edge-config/build-mbed-edge-devmode-test

--- a/.github/workflows/misspell.yml
+++ b/.github/workflows/misspell.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   static-checks:
-    runs-on: ubuntu-latest
+    runs-on: [ "self-hosted", "client" ]
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/pr-check-tests.yml
+++ b/.github/workflows/pr-check-tests.yml
@@ -15,7 +15,7 @@ jobs:
 
   make-test-valgrind:
 
-    runs-on: [ "self-hosted", "edge-builder" ]
+    runs-on: [ "self-hosted", "client" ]
     env:
       SCRIPTS_INTERNAL_DIR: scripts-internal
       EDGE_CONFIGS_DIR: scripts-internal/edge/edge-config/build-mbed-edge-devmode-test


### PR DESCRIPTION
# Mbed Edge pull request


## Description

We do not have the `edge-builder` runner anymore, we should be able to use the `client` runners though. Change the workflows to use client-labeled runners.

## Test instructions

CI change, if jobs pass - all OK.

## Check list

### API change(s)

 - [x] Not applicable.
 - [ ] API is backwards compatible.
 - [ ] API documentation is updated.

### Example applications updated

 - [x] Not applicable.
 
 ### Changelog
 
 - [N/A] `CHANGELOG.md` updated.

