### PR TITLE
Subdev logging fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Update `Dockerfile` base image to Ubuntu 22.04 (from Ubuntu 20.04).
 * Fixed numerous small spelling mistakes pointed by `misspell`.
 * Improve error logging in subdevice FOTA download case.
+* Change subdevice FOTA download folder default from `.` to `/tmp`.
 
 ## Release 0.21.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Update `cURL` to version 8.5.0 (from 7.87.0).
 * Update `Dockerfile` base image to Ubuntu 22.04 (from Ubuntu 20.04).
 * Fixed numerous small spelling mistakes pointed by `misspell`.
+* Improve error logging in subdevice FOTA download case.
 
 ## Release 0.21.0
 

--- a/edge-client/edge-client/subdevice_fota.h
+++ b/edge-client/edge-client/subdevice_fota.h
@@ -1,6 +1,7 @@
 /*
  * ----------------------------------------------------------------------------
  * Copyright 2021 Pelion Ltd.
+ * Copyright 2022-2024 Izuma Networks
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/edge-client/edge-client/subdevice_fota.h
+++ b/edge-client/edge-client/subdevice_fota.h
@@ -49,7 +49,7 @@
 #define ENDPOINT_SIZE 256
 #define MANIFEST_URI_SIZE 256
 #if !defined(SUBDEVICE_FIRMWARE_DOWNLOAD_LOCATION)
-#define SUBDEVICE_FIRMWARE_DOWNLOAD_LOCATION "."
+#define SUBDEVICE_FIRMWARE_DOWNLOAD_LOCATION "/tmp"
 #endif
 int fota_is_ready(uint8_t *data, size_t size, fota_state_e *fota_state);
 int fota_manifest_parse(const uint8_t *input_data, size_t input_size, manifest_firmware_info_t *fw_info);

--- a/edge-client/subdevice_fota.cpp
+++ b/edge-client/subdevice_fota.cpp
@@ -254,6 +254,7 @@ int start_download(char* downloaded_path) {
             curl_easy_cleanup(curl_handle);
             curl_global_cleanup();
             fclose(fwfile);
+            tr_error("can not download firmware %s, aborting", fota_ctx->fw_info->uri);
             subdevice_abort_update(FOTA_STATUS_DOWNLOAD_AUTH_NOT_GRANTED, "can not download firmware");
             return FOTA_STATUS_DOWNLOAD_AUTH_NOT_GRANTED;
         }

--- a/edge-client/subdevice_fota.cpp
+++ b/edge-client/subdevice_fota.cpp
@@ -1,6 +1,7 @@
 /*
  * ----------------------------------------------------------------------------
  * Copyright 2021 Pelion Ltd.
+ * Copyright 2022-2024 Izuma Networks
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -236,6 +237,7 @@ int start_download(char* downloaded_path) {
     char filename[FILENAME_MAX] = "";
     sprintf(filename,"%s/%s-%" PRIu64 ".bin",SUBDEVICE_FIRMWARE_DOWNLOAD_LOCATION,fota_ctx->fw_info->component_name, fota_ctx->fw_info->version);
     tr_info("File location: %s", filename);
+    tr_info("File URL     : %s", fota_ctx->fw_info->uri);
     fota_ctx->state = FOTA_STATE_DOWNLOADING;
     CURL *curl_handle;
     FILE *fwfile;
@@ -261,7 +263,7 @@ int start_download(char* downloaded_path) {
         }
     }
     else {
-        tr_error("can not open file, aborting");
+        tr_error("can not open file %s, aborting", filename);
         subdevice_abort_update(FOTA_STATUS_STORAGE_WRITE_FAILED,"Can not open file, aborting the update!");
         curl_easy_cleanup(curl_handle);
         curl_global_cleanup();


### PR DESCRIPTION
# Mbed Edge pull request

## Description

Improve subdevice FOTA logging in firmware downloads.

## Test instructions

1. Configure the FW download path to a folder, which does not exist (or to which we have no write rights). Verify logs.

2. Use a file download URL, which does not contain a file. Verify logs.

## Check list

### API change(s)

 - [x] Not applicable.
 - [ ] API is backwards compatible.
 - [ ] API documentation is updated.

### Example applications updated

 - [x] Not applicable.
 
 ### Changelog
 
 - [x] `CHANGELOG.md` updated.

