### PR TITLE
PR - use re-usable misspell action

### DIFF
--- a/.github/workflows/misspell.yml
+++ b/.github/workflows/misspell.yml
@@ -1,5 +1,7 @@
 name: misspell
-on: push
+on:
+  push:
+  workflow_dispatch:
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:
@@ -12,9 +14,7 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-      - name: Run misspell (findings may not increase)
-        if: always()
-        run: |
-            curl -L -o ./install-misspell.sh https://git.io/misspell
-            sh ./install-misspell.sh
-            bin/misspell -i mosquitto .
+      - name: Misspell
+        uses: PelionIoT/actions/.github/actions/misspell@main
+        with:
+          exceptions: "mosquitto"


### PR DESCRIPTION

## Description

Use re-usable misspell action. This allows central configuration of versions used.

## Test instructions

If misspell passes, it's OK.

## Check list

### API change(s)

 - [x] Not applicable.
 - [ ] API is backwards compatible.
 - [ ] API documentation is updated.

### Example applications updated

 - [x] Not applicable.
 
 ### Changelog
 
 - [ ] `CHANGELOG.md` updated -- NOT APPLICABLE, CI change.


